### PR TITLE
Use dynamic High Contrast Mode color keyword

### DIFF
--- a/scss/base/_media.scss
+++ b/scss/base/_media.scss
@@ -11,15 +11,6 @@ svg {
   display: block;
 
   @media screen and (-ms-high-contrast: active) {
-    $_accessible-blue: #0074d9;
-    fill: $_accessible-blue;
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    fill: $color-offblack;
-  }
-
-  @media screen and (-ms-high-contrast: white-on-black) {
-    fill: $color-offwhite;
+    fill: windowText;
   }
 }


### PR DESCRIPTION
This PR:

- Removes the `black-on-white` and `white-on-black` HCM media queries.
- Uses `windowText` for SVGs, making them whatever color the text color is set to in the user's HCM theme. 

This will ensure that the SVG color always matches the user's stated preference, including the the `black-on-white` and `white-on-black` themes.